### PR TITLE
add error reporting to emailservice, shippingservice, currencyservice

### DIFF
--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -27,22 +27,22 @@ spec:
           image: asia.gcr.io/next-tokyo-store-demo/frontend
           ports:
           - containerPort: 8080
-          readinessProbe:
-            initialDelaySeconds: 10
-            httpGet:
-              path: "/"
-              port: 8080
-              httpHeaders:
-              - name: "Cookie"
-                value: "shop_session-id=x-readiness-probe"
-          livenessProbe:
-            initialDelaySeconds: 10
-            httpGet:
-              path: "/"
-              port: 8080
-              httpHeaders:
-              - name: "Cookie"
-                value: "shop_session-id=x-liveness-probe"
+          # readinessProbe:
+          #   initialDelaySeconds: 10
+          #   httpGet:
+          #     path: "/"
+          #     port: 8080
+          #     httpHeaders:
+          #     - name: "Cookie"
+          #       value: "shop_session-id=x-readiness-probe"
+          # livenessProbe:
+          #   initialDelaySeconds: 10
+          #   httpGet:
+          #     path: "/"
+          #     port: 8080
+          #     httpHeaders:
+          #     - name: "Cookie"
+          #       value: "shop_session-id=x-liveness-probe"
           env:
           - name: STORE_JSON_PATH
             value: "store.json"

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -12,42 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: loadgenerator
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: loadgenerator
-    spec:
-      terminationGracePeriodSeconds: 5
-      restartPolicy: Always
-      initContainers:
-      - name: wait-frontend
-        image: alpine:3.6
-        command: ['sh', '-c', 'set -x;  apk add --no-cache curl; 
-          until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do 
-            echo "waiting for http://${FRONTEND_ADDR}"; 
-            sleep 2;
-          done;']
-        env:
-        - name: FRONTEND_ADDR
-          value: "frontend:80"
-      containers:
-      - name: main
-        image: asia.gcr.io/next-tokyo-store-demo/loadgenerator
-        env:
-        - name: FRONTEND_ADDR
-          value: "frontend:80"
-        - name: USERS
-          value: "10"
-        resources:
-          requests:
-            cpu: 300m
-            memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
+# apiVersion: extensions/v1beta1
+# kind: Deployment
+# metadata:
+#   name: loadgenerator
+# spec:
+#   replicas: 1
+#   template:
+#     metadata:
+#       labels:
+#         app: loadgenerator
+#     spec:
+#       terminationGracePeriodSeconds: 5
+#       restartPolicy: Always
+#       initContainers:
+#       - name: wait-frontend
+#         image: alpine:3.6
+#         command: ['sh', '-c', 'set -x;  apk add --no-cache curl;
+#           until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do
+#             echo "waiting for http://${FRONTEND_ADDR}";
+#             sleep 2;
+#           done;']
+#         env:
+#         - name: FRONTEND_ADDR
+#           value: "frontend:80"
+#       containers:
+#       - name: main
+#         image: asia.gcr.io/next-tokyo-store-demo/loadgenerator
+#         env:
+#         - name: FRONTEND_ADDR
+#           value: "frontend:80"
+#         - name: USERS
+#           value: "10"
+#         resources:
+#           requests:
+#             cpu: 300m
+#             memory: 256Mi
+#           limits:
+#             cpu: 500m
+#             memory: 512Mi

--- a/src/currencyservice/package-lock.json
+++ b/src/currencyservice/package-lock.json
@@ -89,6 +89,48 @@
         }
       }
     },
+    "@google-cloud/error-reporting": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/error-reporting/-/error-reporting-0.5.1.tgz",
+      "integrity": "sha512-1mTpT2BT5PZEy7DvXq0Uiq2eqIJ4fgrqX8MHITqt8dGK4O97Vw3fSjIauNwp1XFik2f8LfGYyO+G2wA8yzhwbw==",
+      "requires": {
+        "@google-cloud/common": "^0.20.3",
+        "is": "^3.2.1",
+        "lodash.has": "^4.5.2"
+      },
+      "dependencies": {
+        "@google-cloud/common": {
+          "version": "0.20.3",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.20.3.tgz",
+          "integrity": "sha512-jt8/R4EqDTQccv5WA9AEaS65llM5+mlxsuWu57G5Os8HTIpgPbcsOVMUeIvmTrBuPUYSoRIMW8d/pvv/95n0+g==",
+          "requires": {
+            "@types/duplexify": "^3.5.0",
+            "@types/request": "^2.47.0",
+            "arrify": "^1.0.1",
+            "axios": "^0.18.0",
+            "duplexify": "^3.6.0",
+            "ent": "^2.2.0",
+            "extend": "^3.0.1",
+            "google-auth-library": "^1.6.0",
+            "is": "^3.2.1",
+            "pify": "^3.0.0",
+            "request": "^2.87.0",
+            "retry-request": "^4.0.0",
+            "split-array-stream": "^2.0.0",
+            "stream-events": "^1.0.4",
+            "through2": "^2.0.3"
+          }
+        },
+        "retry-request": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.0.0.tgz",
+          "integrity": "sha512-S4HNLaWcMP6r8E4TMH52Y7/pM8uNayOcTDDQNBwsCccL1uI+Ol2TljxRDPzaNfbhOB30+XWP5NnZkB3LiJxi1w==",
+          "requires": {
+            "through2": "^2.0.0"
+          }
+        }
+      }
+    },
     "@google-cloud/profiler": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/@google-cloud/profiler/-/profiler-0.1.14.tgz",
@@ -1390,6 +1432,11 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -1399,6 +1446,11 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
       "integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.isequal": {
       "version": "4.5.0",

--- a/src/currencyservice/package.json
+++ b/src/currencyservice/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/debug-agent": "^2.6.0",
+    "@google-cloud/error-reporting": "^0.5.1",
     "@google-cloud/profiler": "^0.1.14",
     "@google-cloud/trace-agent": "^2.11.0",
     "async": "^1.5.2",

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -22,6 +22,7 @@ import time
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateError
 from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import error_reporting
 import grpc
 
 import demo_pb2
@@ -107,6 +108,12 @@ class EmailService(demo_pb2_grpc.EmailServiceServicer):
 class DummyEmailService(demo_pb2_grpc.EmailServiceServicer):
   def SendOrderConfirmation(self, request, context):
     print('A request to send order confirmation email to {} has been received.'.format(request.email))
+
+    # Next Tokyo: create intentional error message when request email address is "next@tokyo.jp"
+    if request.email == "next@tokyo.jp":
+      client = error_reporting.Client()
+      client.report('This user is in the blacklist: {}'.format(request.email))
+
     return demo_pb2.Empty()
 
 def start(dummy_mode):

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -4,6 +4,7 @@ chardet==3.0.4
 cryptography==1.7.1
 google-api-core==1.2.1
 google-auth==1.5.0
+google-cloud-error-reporting==0.30.0
 google-cloud-core==0.28.1
 google-cloud-trace==0.19.0
 googleapis-common-protos==1.5.3

--- a/src/shippingservice/Gopkg.lock
+++ b/src/shippingservice/Gopkg.lock
@@ -6,6 +6,8 @@
   packages = [
     "compute/metadata",
     "internal/version",
+    "errorreporting",
+    "errorreporting/apiv1beta1",
     "monitoring/apiv3",
     "profiler",
     "trace/apiv2"
@@ -49,6 +51,12 @@
   packages = ["."]
   revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
   version = "v2.0.0"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "go.opencensus.io"
@@ -173,6 +181,7 @@
     "googleapis/api/label",
     "googleapis/api/metric",
     "googleapis/api/monitoredres",
+    "googleapis/devtools/clouderrorreporting/v1beta1",
     "googleapis/devtools/cloudprofiler/v2",
     "googleapis/devtools/cloudtrace/v2",
     "googleapis/monitoring/v3",


### PR DESCRIPTION
add examples to use error reporting in Python, Go and node.js in respective services.

also comment out the configurations that would print a large amount of messages due to health check. those comments should be removed in the end.