### PR TITLE
change the intervals between requests and # of workers

### DIFF
--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -43,7 +43,7 @@ spec:
         - name: FRONTEND_ADDR
           value: "frontend:80"
         - name: USERS
-          value: "3"
+          value: "5"
         resources:
           requests:
             cpu: 300m

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -43,7 +43,7 @@ spec:
         - name: FRONTEND_ADDR
           value: "frontend:80"
         - name: USERS
-          value: "10"
+          value: "3"
         resources:
           requests:
             cpu: 300m

--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -78,5 +78,5 @@ class UserBehavior(TaskSet):
 
 class WebsiteUser(HttpLocust):
     task_set = UserBehavior
-    min_wait = 1000
-    max_wait = 10000
+    min_wait = 1000 * 60
+    max_wait = 10000 * 60

--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -32,7 +32,7 @@ def index(l):
     l.client.get("/")
 
 def setCurrency(l):
-    currencies = ['EUR', 'USD', 'JPY', 'CAD']
+    currencies = ['EUR', 'USD', 'JPY']
     l.client.post("/setCurrency",
         {'currency_code': random.choice(currencies)})
 
@@ -47,12 +47,12 @@ def addToCart(l):
     l.client.get("/product/" + product)
     l.client.post("/cart", {
         'product_id': product,
-        'quantity': random.choice([1,2,3,4,5,10])})
+        'quantity': random.choice([1,2,3,5])})
 
 def checkout(l):
     addToCart(l)
     l.client.post("/cart/checkout", {
-        'email': 'someone@example.com',
+        'email': 'next@tokyo.jp',
         'street_address': '1600 Amphitheatre Parkway',
         'zip_code': '94043',
         'city': 'Mountain View',
@@ -78,5 +78,5 @@ class UserBehavior(TaskSet):
 
 class WebsiteUser(HttpLocust):
     task_set = UserBehavior
-    min_wait = 1000 * 60
-    max_wait = 10000 * 60
+    min_wait = 1000 * 10
+    max_wait = 1000 * 30


### PR DESCRIPTION
Currently loadgenerator is making too many requests to the system which makes the human user request harder to find in GCP console.
This pull requests makes the number of requests to the system lower.